### PR TITLE
feature/add_check_connection_2nd_url

### DIFF
--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -3,7 +3,8 @@ from src.settings import settings
 
 DATE_TIME_FORMAT = "%d-%m-%Y: %H:%M"
 DISPLAY_TIME = 60 * 24
-CONNECTION_TEST_URL = "https://www.agidel-am.ru"
+CONNECTION_TEST_URL_AGI = "https://www.agidel-am.ru"
+CONNECTION_TEST_URL_YA = "https://www.ya.ru"
 SLEEP_TEST_CONNECTION: int = 20
 
 TZINFO = timezone(timedelta(hours=settings.TIMEZONE_OFFSET))


### PR DESCRIPTION
Добавил проверку работы сайта Яндекс, если не доступен сайт Агидель.
Случай простоя фиксируется при недоступности обоих сайтов:

```
  async def check_connection(
            self,
            CONNECTION_TEST_URL_AGI: str = "https://www.agidel-am.ru"
    ) -> dict[str, int | str]:
        """ Проверяет наличие доступа к интернет."""
        try:
            status_code_url_agidel = requests.get(CONNECTION_TEST_URL_AGI).status_code
        except requests.exceptions.ConnectionError:  # если ошибка соединения с сайтом Агидель
            status_code_url_ya = requests.get(CONNECTION_TEST_URL_YA).status_code
            result = {
                CONNECTION_TEST_URL_AGI: "ConnectionError",
                CONNECTION_TEST_URL_YA: status_code_url_ya,
                "time": datetime.now(TZINFO).isoformat(timespec='seconds')
            }
            print(result)  # TODO заменить логированием
            return result
        result = {
            CONNECTION_TEST_URL_AGI: status_code_url_agidel,
            CONNECTION_TEST_URL_YA: "Didn't try, suppose OK!",
            "time": datetime.now(TZINFO).isoformat(timespec='seconds')
        }
        print(result)  #TODO заменить логированием
        return result
```
