### PR TITLE
feature/fix_datetime_in_swagger_forms_presentation

### DIFF
--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -8,9 +8,11 @@ CONNECTION_TEST_URL_YA = "https://www.ya.ru"
 SLEEP_TEST_CONNECTION: int = 20
 
 TZINFO = timezone(timedelta(hours=settings.TIMEZONE_OFFSET))
-
+ANALYTIC_FROM_TIME = (datetime.now(TZINFO) - timedelta(days=1)).strftime(DATE_TIME_FORMAT)
+ANALYTIC_TO_TIME = (datetime.now(TZINFO)).strftime(DATE_TIME_FORMAT)
+CREATE_SUSPENSION_FROM_TIME = (datetime.now(TZINFO) - timedelta(minutes=5)).strftime(DATE_TIME_FORMAT)
+CREATE_SUSPENSION_TO_TIME = (datetime.now(TZINFO) - timedelta(minutes=1)).strftime(DATE_TIME_FORMAT)
 FROM_TIME = (datetime.now(TZINFO) - timedelta(minutes=5)).isoformat(timespec='minutes')
 FROM_TIME_NOW = (datetime.now(TZINFO) - timedelta(days=1)).isoformat(timespec='minutes')
-
 TO_TIME = (datetime.now(TZINFO) - timedelta(minutes=1)).isoformat(timespec='minutes')
 TO_TIME_PERIOD = (datetime.now(TZINFO) - timedelta(minutes=0)).isoformat(timespec='minutes')

--- a/src/core/db/repository/base.py
+++ b/src/core/db/repository/base.py
@@ -103,6 +103,7 @@ class ContentRepository(AbstractRepository, abc.ABC):
             select(self._model)
             .where(self._model.datetime_start >= datetime_start)
             .where(self._model.datetime_finish <= datetime_finish)
+            .order_by(self._model.datetime_start.desc())
         )
         return objects.scalars().all()
 

--- a/src/core/db/repository/suspension.py
+++ b/src/core/db/repository/suspension.py
@@ -18,6 +18,6 @@ class SuspensionRepository(ContentRepository):
         """Возвращает все объекты модели из базы данных, отсортированные по времени."""
         objects = await self._session.execute(
             select(Suspension)
-            .order_by(Suspension.datetime_start)
+            .order_by(Suspension.datetime_start.desc())
         )
         return objects.scalars().all()


### PR DESCRIPTION
Изменил отображение в формах даты и времени

# Why?
Сейчас дата и время в формах сваггер отображаются криво в формате: `2023-11-26T10:05+05:00`
С этим неудобно работать.
Нужно исправить под формат: `%d-%m-%Y: %H:%M`


![Image](https://github.com/ArtemBalandin81/tech_accidents/assets/105808126/d1386fbd-aa72-4129-831d-85fc464a13ec)