### PR TITLE
feature/add_my_suspensions_and_suspensions_by_user_id

### DIFF
--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -120,7 +120,7 @@ class SuspensionAnalytics(BaseModel):
 
     suspensions_in_mins_total: int
     suspensions_total: int
-    max_suspension_time_for_period: int
+    suspension_max_time_for_period: int
     last_time_suspension: datetime
     last_time_suspension_id: int
     # suspensions: list[SuspensionResponse] = {}

--- a/src/core/db/repository/suspension.py
+++ b/src/core/db/repository/suspension.py
@@ -1,10 +1,12 @@
 """src/core/db/repository/suspension.py"""
+from collections.abc import Sequence
+from datetime import datetime
 from fastapi import Depends
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.core.db.db import get_session
-from src.core.db.models import Suspension
+from src.core.db.models import Suspension, User
 from src.core.db.repository.base import ContentRepository
 
 
@@ -14,6 +16,21 @@ class SuspensionRepository(ContentRepository):
     def __init__(self, session: AsyncSession = Depends(get_session)) -> None:
         super().__init__(session, Suspension)
 
+    async def count_for_period_for_user(
+            self,
+            user_id: int,
+            datetime_start: datetime,
+            datetime_finish: datetime,
+
+    ) -> int:
+        """Считает количество простоев за указанные период для пользователя."""
+        return await self._session.scalar(
+            select(func.count(Suspension.datetime_start))
+            .where(Suspension.user_id == user_id)
+            .where(Suspension.datetime_start >= datetime_start)
+            .where(Suspension.datetime_finish <= datetime_finish)
+        )
+
     async def get_all(self) -> list[Suspension]:
         """Возвращает все объекты модели из базы данных, отсортированные по времени."""
         objects = await self._session.execute(
@@ -21,3 +38,68 @@ class SuspensionRepository(ContentRepository):
             .order_by(Suspension.datetime_start.desc())
         )
         return objects.scalars().all()
+
+    async def get_last_id_for_user(self, user_id: int) -> int:
+        """Возвращает последний по времени простой для пользователя."""
+        return await self._session.scalar(
+            select(Suspension.id)
+            .where(Suspension.user_id == user_id)
+            .order_by(Suspension.id.desc())
+        )
+
+    async def get_suspensions_for_user(self, user_id: int, limit: int = 3, offset: int = 0) -> Sequence[Suspension]:
+        """Получить список простоев пользователя."""
+        suspensions_for_user = await self._session.scalars(
+            select(Suspension)
+            .where(Suspension.user_id == user_id)
+            # .limit(limit)  # todo реализовать пагинацию
+            # .offset(offset)
+            .order_by(Suspension.datetime_start.desc())
+        )
+        return suspensions_for_user.all()
+
+    async def get_suspensions_for_period_for_user(
+            self,
+            user_id: int,
+            datetime_start: datetime,
+            datetime_finish: datetime
+    ) -> Sequence[Suspension]:
+        """Получить список простоев пользователя за выбранный период времени."""
+        suspensions_for_user_for_period = await self._session.scalars(
+            select(Suspension)
+            .where(Suspension.user_id == user_id)
+            .where(Suspension.datetime_start >= datetime_start)
+            .where(Suspension.datetime_finish <= datetime_finish)
+            .order_by(Suspension.datetime_start.desc())
+            .order_by(Suspension.datetime_start.desc())
+        )
+        return suspensions_for_user_for_period.all()
+
+    async def suspension_max_time_for_period_for_user(
+            self,
+            user_id: int,
+            datetime_start: datetime,
+            datetime_finish: datetime
+    ) -> int:
+        """Считает максимальную разницу между началом и концом за указанный период для пользователя."""
+        return await self._session.scalar(
+            select(func.max(func.julianday(Suspension.datetime_finish) - func.julianday(Suspension.datetime_start)))
+            .where(Suspension.user_id == user_id)
+            .where(Suspension.datetime_start >= datetime_start)
+            .where(Suspension.datetime_finish <= datetime_finish)
+        )
+
+    async def sum_time_for_period_for_user(
+            self,
+            user_id: int,
+            datetime_start: datetime,
+            datetime_finish: datetime,
+
+    ) -> int:
+        """Считает время в днях за указанный период для пользователя."""
+        return await self._session.scalar(
+            select(func.sum(func.julianday(Suspension.datetime_finish) - func.julianday(Suspension.datetime_start)))
+            .where(Suspension.user_id == user_id)
+            .where(Suspension.datetime_start >= datetime_start)
+            .where(Suspension.datetime_finish <= datetime_finish)
+        )


### PR DESCRIPTION
Добавлен эндпоинт, который будет показывать случаи простоя, добавленные текущим пользователем

В аналитику добавлена фильтрация случаев простоя по user_id:
- если user_id не указан, выводятся все простои за период и аналитика по ним
- если указан, то - только по этому пользователю

В сервисы suspension добавлена обработка этих двух случаев
Для этого в репозиторий suspension скопированы методы из base и в них добавлена фильтрация по user_id