### PR TITLE
fix/refactoring_session.scalar

### DIFF
--- a/src/api/services/base.py
+++ b/src/api/services/base.py
@@ -30,6 +30,3 @@ class ContentService(abc.ABC):
                 await self._repository.update_all(to_update, commit=False)
             await session.commit()
             return [obj.id for obj in to_create]
-
-    async def get_all(self) -> list[any]:
-        return await self._repository.get_all()

--- a/src/core/db/repository/suspension.py
+++ b/src/core/db/repository/suspension.py
@@ -31,13 +31,13 @@ class SuspensionRepository(ContentRepository):
             .where(Suspension.datetime_finish <= datetime_finish)
         )
 
-    async def get_all(self) -> list[Suspension]:
+    async def get_all(self) -> Sequence[Suspension]:
         """Возвращает все объекты модели из базы данных, отсортированные по времени."""
-        objects = await self._session.execute(
+        objects = await self._session.scalars(
             select(Suspension)
             .order_by(Suspension.datetime_start.desc())
         )
-        return objects.scalars().all()
+        return objects.all()
 
     async def get_last_id_for_user(self, user_id: int) -> int:
         """Возвращает последний по времени простой для пользователя."""


### PR DESCRIPTION
# Why?
Сейчас в разных репозиториях объекты класса ScalarResult возвращаются по разному.
В целях единообразия откажемся от применения метода session.scalars().
Кроме того, он ухудшает читаемость кода.

# How To Do?

- Пример того, что меняем:
```python
    async def get_all(self) -> list[DatabaseModel]:
        """Возвращает все объекты модели из базы данных."""
        objects = await self._session.execute(select(self._model))
        return objects.scalars().all()
```

- Примеры того, как должно быть:
```python
from typing import Sequence
....
    async def get_all(self) -> Sequence[DatabaseModel]:
        """Возвращает все объекты модели из базы данных."""
        objects = await self._session.scalars(select(self._model))
        return objects.all()



